### PR TITLE
🐛 Fix bug not allowing files to be opened

### DIFF
--- a/app/src/main_process/ipc.ts
+++ b/app/src/main_process/ipc.ts
@@ -4,11 +4,11 @@ import { assertSome } from '../util';
 ipcMain.handle('open-file', (event, options) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   assertSome(win);
-  return dialog.showOpenDialogSync(win, options);
+  return dialog.showOpenDialog(win, options);
 });
 
 ipcMain.handle('save-file', (event, options) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   assertSome(win);
-  return dialog.showSaveDialogSync(win, options);
+  return dialog.showSaveDialog(win, options);
 });


### PR DESCRIPTION
showOpenDialogSync/showSaveDialogSync returns slightly different values then their non-sync counterparts. Instead of an object with a filePath(s) and a canceled attribute they return a String / String[] with filepaths and unknown if they were canceled